### PR TITLE
Typed C representation

### DIFF
--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -15,95 +15,172 @@ let fresh_var =
     incr var_counter;
     Printf.sprintf "x%d" !var_counter
 
-type ty = Ty : _ typ -> ty
-type tfn = Fn : _ fn -> tfn
+type value_
+type value = value_ abstract
+let value : value typ = abstract ~name:"value" ~size:0 ~alignment:0
 
-type cfunction = {
+type stmt_
+type stmt = stmt_ abstract
+let stmt : stmt typ = abstract ~name:"stmt" ~size:0 ~alignment:0
+
+type (_, _) fn =
+    Returns_  : 'r typ  -> ('r, 'r) fn
+  | Function_ : 'a typ * ('b, 'r) fn  -> ('a -> 'b, 'r) fn
+
+type 'a fn_wrapper = Fn_wrapped : ('a, 'r) fn -> 'a fn_wrapper
+
+let rec wrap_fn : type a. a Static.fn -> a fn_wrapper =
+ fun fn -> match fn with
+   Returns ty  -> Fn_wrapped (Returns_ ty)
+ | Function (p, fn') ->
+    let (Fn_wrapped fn'') = wrap_fn fn' in
+    Fn_wrapped (Function_ (p, fn''))
+
+type ('a, 'r) cfunction = {
   fname: string;
   allocates: bool;
   reads_ocaml_heap: bool;
-  fn: tfn;
+  fn: ('a, 'r) fn;
 }
 
-type cvar_details = {
+type 'a cvar_details = {
   name: string;
-  typ: ty;
+  typ: 'a typ;
   references_ocaml_heap: bool;
 }
 
-type clocal = [ `Local of cvar_details ]
-type cglobal = [ `Global of cvar_details ]
-type cvar = [ clocal | cglobal ]
-type cconst = [ `Int of int ]
-type cexp = [ cconst
-            | clocal
-            | `Cast of ty * cexp
-            | `Addr of cexp ]
-type clvalue = [ cvar | `Index of clvalue * cexp ]
+type 'a clocal = [ `Local of 'a cvar_details ]
+type 'a cglobal = [ `Global of 'a cvar_details ]
+type 'a cvar = [ 'a clocal | 'a cglobal ]
+type _ cconst =
+    CInt : int -> int cconst
+  | CSizeof : _ typ -> Unsigned.size_t cconst
+type 'a cexp = CConst of 'a cconst
+             | CLocal of 'a cvar_details
+             | CCast : 'a typ * _ cexp -> 'a cexp
+             | CAddr : 'a cexp -> 'a ptr cexp
+type 'a clvalue =
+    CVar of 'a cvar
+  | CAIndex_ : 'a carray clvalue * int cexp -> 'a clvalue
+  | CPIndex_ : 'a ptr clvalue * int cexp -> 'a clvalue
 type camlop = [ `CAMLparam0
-              | `CAMLlocalN of cexp * cexp ]
-type ceff = [ cexp
-            | camlop
-            | cglobal
-            | `App of cfunction * cexp list
-            | `If of cexp * ceff * ceff
-            | `Index of ceff * cexp
-            | `Deref of cexp
-            | `Assign of clvalue * ceff ]
-type cbind = clocal * ceff
-type ccomp = [ ceff
-             | `LetConst of clocal * cconst * ccomp
-             | `CAMLreturnT of ty * cexp
-             | `Let of cbind * ccomp ]
-type cfundec = [ `Fundec of string * cvar_details list * ty ]
-type cfundef = [ `Function of cfundec * ccomp ]
+              | `CAMLlocalN of value carray cvar_details * int cexp ]
 
-let rec return_type : type a. a fn -> ty = function
-  | Function (_, f) -> return_type f
-  | Returns t -> Ty t
+type (_, _) ocaml_pointer =
+    OString : (string ocaml, char ptr) ocaml_pointer
+  | OBytes : (Bytes.t ocaml, char ptr) ocaml_pointer
+  | OFloatArray : (float array ocaml, float ptr) ocaml_pointer
 
-let args : type a. a fn -> cvar_details list = fun fn ->
-  let rec loop : type a. a Ctypes.fn -> cvar_details list = function
-    | Static.Function (ty, fn) ->
-       {name=fresh_var (); references_ocaml_heap=true; typ=Ty ty} :: loop fn
-    | Static.Returns _ -> []
+type 'a arg =
+    Arg of 'a cexp
+  | Nothing of ('a, unit) view
+  | OCamlArg : ('a, 'o) ocaml_pointer * 'o cexp -> 'a arg
+
+type 'a args =
+    End
+  | Args : 'a arg * 'b args -> ('a -> 'b) args
+
+type 'a ceff =
+    CExp of 'a cexp
+  | CamlOp : camlop -> stmt ceff
+  | CGlobal of 'a cvar_details
+  | CApp : ('a, 'r) cfunction * 'a args -> 'r ceff
+  | CIf of bool cexp * 'a ceff * 'a ceff
+  | CPIndex of 'a ptr ceff * int cexp
+  | CAIndex of 'a carray ceff * int cexp
+  | CDeref of 'a ptr cexp
+  | CAssign : 'a clvalue * 'a ceff -> stmt ceff
+type 'a cbind = CBind of 'a cvar_details * 'a ceff
+type 'a ccomp = (* This isn't quite right: it doesn't handle the return type properly *)
+    CEff of 'a ceff
+  | CLetConst : _ cvar_details * _ cconst * 'a ccomp -> 'a ccomp
+  | CCAMLreturnT of 'a typ * 'a cexp
+  | CCAMLreturn0 of ('a, unit) view
+  | CLet : _ cbind * 'a ccomp -> 'a ccomp
+type _ params =
+    NoParams
+  | Param : 'a cvar_details * 'b params -> ('a -> 'b) params
+type ('a, 'r) cfundec = Fundec of string * 'a params * 'r typ
+type 'a cfundef = Fundef : ('a, 'r) cfundec * 'r ccomp -> 'a cfundef
+
+let rec args_length : type a. a args -> int = function
+ | End -> 0
+ | Args (Nothing _, xs) -> args_length xs
+ | Args ((OCamlArg _| Arg _), xs) -> 1 + args_length xs
+
+let rec params_length : type a. a params -> int = function
+    NoParams -> 0
+  | Param (_, p) -> 1 + params_length p
+
+let rec return_type : type a r. (a, r) fn -> r typ = function
+    Returns_ t -> t
+  | Function_ (_, f) -> return_type f
+
+let params : type a r. (a, r) fn -> a params = fun fn ->
+  let rec loop : type a. (a, r) fn -> a params = function
+      Returns_ _ -> NoParams
+    | Function_ (typ, fn) ->
+       Param ({name=fresh_var (); references_ocaml_heap=true; typ}, loop fn)
   in loop fn
+
+type iteri_arg = { argf : 'a. int -> 'a cexp -> unit }
+
+let iteri_args : type a. f:iteri_arg -> a args -> unit =
+  fun ~f:{argf=f} args ->
+  let rec loop : type a. int -> a args -> unit =
+    fun i -> function
+   | End -> ()
+   | Args (Arg x, xs) -> f i x; loop (i+1) xs
+   | Args (OCamlArg (_, x), xs) -> f i x; loop (i+1) xs
+   | Args (Nothing _, xs) -> loop (i+1) xs
+ in loop 0 args
+
+type iteri_param = { paramf : 'a. int -> 'a cvar_details -> unit }
+
+let rec iteri_params : type a. f:iteri_param -> a params -> unit =
+  fun ~f:{paramf=f} params ->
+  let rec loop : type a r. int -> a params -> unit =
+    fun i -> function
+   | NoParams -> ()
+   | Param (x, xs) -> f i x; loop (i+1) xs
+ in loop 0 params
 
 module Type_C =
 struct
-  let rec cexp : cexp -> ty = function
-    | `Int _ -> Ty int
-    | `Local {typ} -> typ
-    | `Cast (typ, _) -> typ
-    | `Addr e -> let Ty ty = cexp e in Ty (Pointer ty)
+  let cconst : type a. a cconst -> a typ = function
+      CInt _ -> int
+    | CSizeof _ -> size_t
 
-  let camlop : camlop -> ty = function
-    | `CAMLparam0
-    | `CAMLlocalN _ -> Ty Void
+  let rec cexp : type a. a cexp -> a typ = function
+      CConst c -> cconst c
+    | CLocal {typ} -> typ
+    | CCast (typ, _) -> typ
+    | CAddr e -> ptr (cexp e)
 
-  let rec ceff : ceff -> ty = function
-    | #cexp as e -> cexp e
-    | #camlop as o -> camlop o
-    | `Global { typ } -> typ
-    | `App ({ fn = Fn f }, _) -> return_type f
-    | `If (_, e, _) -> ceff e
-    | `Index (e, _) -> reference_ceff e
-    | `Deref e -> reference_ceff (e :> ceff)
-    | `Assign (_, rv) -> ceff rv
-  and reference_ceff : ceff -> ty =
+  let rec ceff : type a. a ceff -> a typ = function
+      CExp e -> cexp e
+    | CamlOp o -> stmt
+    | CGlobal { typ } -> typ
+    | CApp ({fn}, _) -> return_type fn
+    | CIf (_, e, _) -> ceff e
+    | CAIndex (e, _) -> array_reference_ceff e
+    | CPIndex (e, _) -> ptr_reference_ceff e
+    | CDeref e -> ptr_reference_ceff (CExp e)
+    | CAssign (_, rv) -> stmt
+  and ptr_reference_ceff : type a. a ptr ceff -> a typ =
     fun e ->
       begin match ceff e with
-      | Ty (Pointer ty) -> Ty ty
-      | Ty (Array (ty, _)) -> Ty ty
-      | Ty t -> Cstubs_errors.internal_error
+        Pointer ty -> ty
+      | t -> Cstubs_errors.internal_error
         "dereferencing expression of non-pointer type %s"
         (Ctypes.string_of_typ t)
       end
-
-  let rec ccomp : ccomp -> ty = function
-    | #cexp as e -> cexp e
-    | #ceff as e -> ceff e
-    | `Let (_, c)
-    | `LetConst (_, _, c) -> ccomp c
-    | `CAMLreturnT (ty, _) -> ty
+  and array_reference_ceff : type a. a carray ceff -> a typ =
+    fun e ->
+      begin match ceff e with
+        Array (ty, _) -> ty
+      | t -> Cstubs_errors.internal_error
+        "dereferencing expression of non-array type %s"
+        (Ctypes.string_of_typ t)
+      end
 end

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -38,7 +38,7 @@ type cexp = [ cconst
             | clocal
             | `Cast of ty * cexp
             | `Addr of cexp ]
-type clvalue = [ clocal | `Index of clvalue * cexp ]
+type clvalue = [ cvar | `Index of clvalue * cexp ]
 type camlop = [ `CAMLparam0
               | `CAMLlocalN of cexp * cexp ]
 type ceff = [ cexp

--- a/src/cstubs/cstubs_c_language.ml
+++ b/src/cstubs/cstubs_c_language.ml
@@ -45,6 +45,7 @@ type ceff = [ cexp
             | camlop
             | `Global of cglobal
             | `App of cfunction * cexp list
+            | `If of cexp * ceff * ceff
             | `Index of ceff * cexp
             | `Deref of cexp
             | `Assign of clvalue * ceff ]
@@ -83,6 +84,7 @@ struct
     | #camlop as o -> camlop o
     | `Global { typ } -> typ
     | `App ({ fn = Fn f }, _) -> return_type f
+    | `If (_, e, _) -> ceff e
     | `Index (e, _) -> reference_ceff e
     | `Deref e -> reference_ceff (e :> ceff)
     | `Assign (_, rv) -> ceff rv

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -69,6 +69,8 @@ let rec ceff fmt : ceff -> unit = function
           (if i <> last_exp then ",@ " else ""))
       es;
     fprintf fmt ")@]@]";
+  | `If (e, s, t) ->
+    fprintf fmt "@[(%a)@]@ ?@ @[(%a)@]@ :@ @[(%a)@]" cexp e ceff s ceff t
   | `Index (e, i) ->
     fprintf fmt "@[@[%a@]@[[%a]@]@]" ceff e cexp i
   | `Deref e -> fprintf fmt "@[*@[%a@]@]" cexp e
@@ -88,7 +90,10 @@ let rec ccomp fmt : ccomp -> unit = function
     ccomp fmt (`Let (xe, e'))
   | `Let ((`Local (x, _), e), `Local (y, _)) when x = y ->
     ccomp fmt (e :> ccomp)
-  | `Let ((`Local (name, Ty Void), e), s) ->
+  | `Let ((`Local (_, Ty Void), `If (e, a, b)), s) ->
+    fprintf fmt "@[if@ (@[%a)@]@ {@[%a}@]@\nelse@ {@[%a}@]@]@ %a"
+      cexp e ceff a ceff b ccomp s
+  | `Let ((`Local (_, Ty Void), e), s) ->
     fprintf fmt "@[%a;@]@ %a" ceff e ccomp s
   | `Let ((`Local (name, Ty (Struct { tag })), e), s) ->
     fprintf fmt "@[struct@;%s@;%s@;=@;@[%a;@]@]@ %a"

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -47,7 +47,7 @@ let rec cexp fmt : cexp -> unit = function
   | `Addr e -> fprintf fmt "@[&@[%a@]@]" cexp e
 
 let rec clvalue fmt : clvalue -> unit = function
-  | `Local _ as x -> cvar fmt x
+  | #cvar as x -> cvar fmt x
   | `Index (lv, i) ->
     fprintf fmt "@[@[%a@]@[[%a]@]@]" clvalue lv cexp i
 

--- a/src/cstubs/cstubs_emit_c.ml
+++ b/src/cstubs/cstubs_emit_c.ml
@@ -11,122 +11,129 @@ open Static
 open Cstubs_c_language
 open Format
 
-let format_seq lbr fmt_item sep rbr fmt items =
-  let open Format in
-  fprintf fmt "%s@[@[" lbr;
-    ListLabels.iteri items ~f:(fun i item ->
-      if i <> 0 then fprintf fmt "@]%s@ @[" sep;
-      fmt_item fmt item);
-  fprintf fmt "@]%s@]" rbr
-
-let format_ty fmt (Ty ty) = Ctypes.format_typ fmt ty
+let format_ty fmt ty = Ctypes.format_typ fmt ty
 
 let cvar_name = function
   | `Local { name } | `Global { name } -> name
 
 let cvar fmt v = fprintf fmt "%s" (cvar_name v)
 
-let cconst fmt (`Int i) = fprintf fmt "%d" i
+let cconst : type a. formatter -> a cconst -> unit = fun fmt -> function
+  | CInt i -> fprintf fmt "%d" i
+  | CSizeof typ -> fprintf fmt "sizeof (%a)" format_ty typ
 
 (* Determine whether the C expression [(ty)e] is equivalent to [e] *)
-let cast_unnecessary : ty -> cexp -> bool =
-  let rec harmless l r = match l, r with
-  | Ty (Pointer Void), Ty (Pointer _) -> true
-  | Ty (View { ty }), t -> harmless (Ty ty) t
-  | t, Ty (View { ty }) -> harmless t (Ty ty)
-  | (Ty (Primitive _) as l), (Ty (Primitive _) as r) -> l = r
+type prim = Prim : _ Primitives.prim -> prim
+let cast_unnecessary : type a b. a typ -> b cexp -> bool =
+  let rec harmless : type a b. a typ -> b typ -> bool =
+    fun l r -> match l, r with
+  | Pointer Void, Pointer _ -> true
+  | View { ty }, t -> harmless ty t
+  | t,  View { ty } -> harmless t ty
+  | Primitive l, Primitive r -> Prim l = Prim r
   | _ -> false
   in
   fun ty e -> harmless ty (Type_C.cexp e)
 
-let rec cexp fmt : cexp -> unit = function
-  | #cconst as c -> cconst fmt c
-  | `Local _ as x -> cvar fmt x
-  | `Cast (ty, e) when cast_unnecessary ty e -> cexp fmt e
-  | `Cast (ty, e) -> fprintf fmt "@[@[(%a)@]%a@]" format_ty ty cexp e
-  | `Addr e -> fprintf fmt "@[&@[%a@]@]" cexp e
+let rec cexp : type a. formatter -> a cexp -> unit = fun fmt -> function
+  | CConst c  -> cconst fmt c
+  | CLocal x -> cvar fmt (`Local x)
+  | CCast (ty, e) when cast_unnecessary ty e -> cexp fmt e
+  | CCast (ty, e) -> fprintf fmt "@[@[(%a)@]%a@]" format_ty ty cexp e
+  | CAddr e -> fprintf fmt "@[&@[%a@]@]" cexp e
 
-let rec clvalue fmt : clvalue -> unit = function
-  | #cvar as x -> cvar fmt x
-  | `Index (lv, i) ->
+let rec clvalue : type a. formatter -> a clvalue -> unit = fun fmt -> function
+  | CVar x -> cvar fmt x
+  | CAIndex_ (lv, i) ->
+    fprintf fmt "@[@[%a@]@[[%a]@]@]" clvalue lv cexp i
+  | CPIndex_ (lv, i) ->
     fprintf fmt "@[@[%a@]@[[%a]@]@]" clvalue lv cexp i
 
 let camlop fmt : camlop -> unit = function
-  | `CAMLparam0 -> Format.fprintf fmt "CAMLparam0()"
-  | `CAMLlocalN (e, c) -> Format.fprintf fmt "CAMLlocalN(@[%a@],@ @[%a@])"
-    cexp e cexp c
+  | `CAMLparam0 -> fprintf fmt "CAMLparam0()"
+  | `CAMLlocalN ({name}, c) -> fprintf fmt "CAMLlocalN(@[%s@],@ @[%a@])"
+    name cexp c
 
-let rec ceff fmt : ceff -> unit = function
-  | #cexp as e -> cexp fmt e
-  | #camlop as o -> camlop fmt o
-  | `Global _ as x -> cvar fmt x
-  | `App ({fname}, es) ->
+let rec ceff : type a. formatter -> a ceff -> unit = fun fmt -> function
+  | CExp e -> cexp fmt e
+  | CamlOp o -> camlop fmt o
+  | CGlobal x -> cvar fmt (`Global x)
+  | CApp ({fname}, es) ->
     fprintf fmt "@[%s(@[" fname;
-    let last_exp = List.length es - 1 in
-    List.iteri
-      (fun i e ->
-        fprintf fmt "@[%a@]%(%)" cexp e
-          (if i <> last_exp then ",@ " else ""))
-      es;
+    let last_exp = args_length es - 1 in
+    iteri_args es
+     ~f:{ argf = fun i e ->
+                 fprintf fmt "@[%a@]%(%)" cexp e
+                         (if i <> last_exp then ",@ " else "")};
     fprintf fmt ")@]@]";
-  | `If (e, s, t) ->
+  | CIf (e, s, t) ->
     fprintf fmt "@[(%a)@]@ ?@ @[(%a)@]@ :@ @[(%a)@]" cexp e ceff s ceff t
-  | `Index (e, i) ->
+  | CAIndex (e, i) ->
     fprintf fmt "@[@[%a@]@[[%a]@]@]" ceff e cexp i
-  | `Deref e -> fprintf fmt "@[*@[%a@]@]" cexp e
-  | `Assign (lv, e) ->
+  | CPIndex (e, i) ->
+    fprintf fmt "@[@[%a@]@[[%a]@]@]" ceff e cexp i
+  | CDeref e -> fprintf fmt "@[*@[%a@]@]" cexp e
+  | CAssign (lv, e) ->
     fprintf fmt "@[@[%a@]@;=@;@[%a@]@]" clvalue lv ceff e
 
-let rec ccomp fmt : ccomp -> unit = function
-  | #cexp as e -> fprintf fmt "@[<2>return@;@[%a@]@];" cexp e
-  | #ceff as e -> fprintf fmt "@[<2>return@;@[%a@]@];" ceff e
-  | `CAMLreturnT (Ty Void, e) ->
+let rec ccomp : type a. formatter -> a ccomp -> unit = fun fmt -> function
+  | CEff e -> fprintf fmt "@[<2>return@;@[%a@]@];" ceff e
+  | CCAMLreturnT (Void, e) ->
     fprintf fmt "@[CAMLreturn0@];"
-  | `CAMLreturnT (Ty ty, e) ->
+  | CCAMLreturn0 _ ->
+    fprintf fmt "@[CAMLreturn0@];"
+  | CCAMLreturnT (ty, e) ->
     fprintf fmt "@[<2>CAMLreturnT(@[%a@],@;@[%a@])@];"
-      (fun t -> Ctypes.format_typ t) ty
-      cexp e
-  | `Let (xe, `Cast (ty, (#cexp as e'))) when cast_unnecessary ty e' ->
-    ccomp fmt (`Let (xe, e'))
-  | `Let ((`Local {name = x}, e), `Local {name=y}) when x = y ->
-    ccomp fmt (e :> ccomp)
-  | `Let ((`Local {typ=Ty Void}, `If (e, a, b)), s) ->
+      format_ty ty cexp e
+  | CLet (CBind (_, (CamlOp _ as e)), s) ->
+     fprintf fmt "@[%a;@]@ %a" ceff e ccomp s
+  | CLet (CBind (_, (CAssign _ as e)), s) ->
+     fprintf fmt "@[%a;@]@ %a" ceff e ccomp s
+  | CLet (xe, CEff (CExp (CCast (ty, e')))) when cast_unnecessary ty e' ->
+    ccomp fmt (CLet (xe, CEff (CExp e')))
+  | CLet (CBind ({name = x}, e), CEff (CExp (CLocal {name=y}))) when x = y ->
+    ccomp fmt (CEff e)
+  | CLet (CBind ({typ=Void}, CIf (e, a, b)), s) ->
     fprintf fmt "@[if@ (@[%a)@]@ {@[%a}@]@\nelse@ {@[%a}@]@]@ %a"
       cexp e ceff a ceff b ccomp s
-  | `Let ((`Local {typ=Ty Void}, e), s) ->
+  | CLet (CBind ({typ=Void}, e), s) ->
     fprintf fmt "@[%a;@]@ %a" ceff e ccomp s
-  | `Let ((`Local {name; typ=Ty (Struct { tag })}, e), s) ->
+  | CLet (CBind ({name; typ=Struct { tag }}, e), s) ->
     fprintf fmt "@[struct@;%s@;%s@;=@;@[%a;@]@]@ %a"
       tag name ceff e ccomp s
-  | `Let ((`Local {name; typ=Ty (Union { utag })}, e), s) ->
+  | CLet (CBind ({name; typ=Union { utag }}, e), s) ->
     fprintf fmt "@[union@;%s@;%s@;=@;@[%a;@]@]@ %a"
       utag name ceff e ccomp s
-  | `Let ((`Local {name; typ=Ty ty}, e), s) ->
+  | CLet (CBind ({name; typ=ty}, e), s) ->
     fprintf fmt "@[@[%a@]@;=@;@[%a;@]@]@ %a"
       (Ctypes.format_typ ~name) ty ceff e ccomp s
-  | `LetConst (`Local {name=x}, `Int c, s) ->
-    fprintf fmt "@[enum@ {@[@ %s@ =@ %d@ };@]@]@ %a"
-      x c ccomp s
+  | CLetConst ({name=x}, c, s) ->
+    fprintf fmt "@[enum@ {@[@ %s@ =@ %a@ };@]@]@ %a"
+     x cconst c ccomp s
 
-let format_parameter_list parameters k fmt =
-  let format_arg fmt {name; typ=Ty t} =
-    Type_printing.format_typ ~name fmt t
+let format_params : type a. a params -> (formatter -> unit) -> (formatter -> unit) =
+  fun parameters k fmt ->
+  let format_param fmt {name; typ=t} = Type_printing.format_typ ~name fmt t in
+  let format_seq fmt parameters =
+    fprintf fmt "(@[@[";
+    iteri_params parameters
+      ~f:{ paramf =
+             fun i item ->
+             if i <> 0 then fprintf fmt "@],@ @[";
+             format_param fmt item };
+    fprintf fmt "@]%s@]" ")"
   in
   match parameters with
-  | [] ->
-    Format.fprintf fmt "%t(void)" k
-  | _ ->
-    Format.fprintf fmt "@[%t@[%a@]@]" k
-      (format_seq "(" format_arg "," ")")
-      parameters
+  | NoParams -> fprintf fmt "%t(void)" k
+  | _ -> fprintf fmt "@[%t@[%a@]@]" k format_seq parameters
 
-let cfundec : Format.formatter -> cfundec -> unit =
-  fun fmt (`Fundec (name, args, Ty return)) ->
+let cfundec : type a r. formatter -> (a, r) cfundec -> unit =
+  fun fmt (Fundec (name, params, return)) ->
     Type_printing.format_typ' return
       (fun context fmt ->
-        format_parameter_list args (Type_printing.format_name ~name) fmt)
+       format_params params (Type_printing.format_name ~name) fmt)
       `nonarray fmt
 
-let cfundef fmt (`Function (dec, body) : cfundef) =
+let cfundef fmt (Fundef (dec, body) : _ cfundef) =
   fprintf fmt "%a@\n{@[<v 2>@\n%a@]@\n}@\n" 
     cfundec dec ccomp body

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -55,7 +55,7 @@ struct
         CCAMLreturnT (Type_C.cexp e, e)
      | CCAMLreturn0 view ->
         CEff val_unit >>= fun u ->
-        k (CCast (View view, u)) >>= fun e ->
+        k (CCast (Typ.of_typ (View view), u)) >>= fun e ->
         CCAMLreturnT (Type_C.cexp e, e)
      | CLet (ye, c) ->
        (* let x = (let y = e1 in e2) in e3
@@ -67,61 +67,62 @@ struct
 
   let prim_prj : type a. a Primitives.prim -> (value -> a, a) cfunction =
     let open Primitives in function
-    | Char -> reader "Int_val" (value @-> returning char)
-    | Schar -> reader "Int_val" (value @-> returning int)
-    | Uchar -> reader "Uint8_val" (value @-> returning uchar)
-    | Short -> reader "Int_val" (value @-> returning int)
-    | Int -> reader "Int_val" (value @-> returning int)
-    | Long -> reader "ctypes_long_val" (value @-> returning long)
-    | Llong -> reader "ctypes_llong_val" (value @-> returning llong)
-    | Ushort -> reader "ctypes_ushort_val" (value @-> returning ushort)
-    | Uint -> reader "ctypes_uint_val" (value @-> returning uint)
-    | Ulong -> reader "ctypes_ulong_val" (value @-> returning ulong)
-    | Ullong -> reader "ctypes_ullong_val" (value @-> returning ullong)
-    | Size_t -> reader "ctypes_size_t_val" (value @-> returning size_t)
-    | Int8_t -> reader "Int_val" (value @-> returning int)
-    | Int16_t -> reader "Int_val" (value @-> returning int)
-    | Int32_t -> reader "Int32_val" (value @-> returning int32_t)
-    | Int64_t -> reader "Int64_val" (value @-> returning int64_t)
-    | Uint8_t -> reader "Uint8_val" (value @-> returning uint8_t)
-    | Uint16_t -> reader "Uint16_val" (value @-> returning uint16_t)
-    | Uint32_t -> reader "Uint32_val" (value @-> returning uint32_t)
-    | Uint64_t -> reader "Uint64_val" (value @-> returning uint64_t)
-    | Camlint -> reader "Int_val" (value @-> returning int)
-    | Nativeint -> reader "Nativeint_val" (value @-> returning nativeint)
-    | Float -> reader "Double_val" (value @-> returning double)
-    | Double -> reader "Double_val" (value @-> returning double)
-    | Complex32 -> reader "ctypes_float_complex_val" (value @-> returning complex32)
-    | Complex64 -> reader "ctypes_double_complex_val" (value @-> returning complex64)
+    | Char -> reader "Int_val" (value @-> returning (Typ.of_typ char))
+    | Schar -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Uchar -> reader "Uint8_val" (value @-> returning (Typ.of_typ uchar))
+    | Short -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Int -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Long -> reader "ctypes_long_val" (value @-> returning (Typ.of_typ long))
+    | Llong -> reader "ctypes_llong_val" (value @-> returning (Typ.of_typ llong))
+    | Ushort -> reader "ctypes_ushort_val" (value @-> returning (Typ.of_typ ushort))
+    | Uint -> reader "ctypes_uint_val" (value @-> returning (Typ.of_typ uint))
+    | Ulong -> reader "ctypes_ulong_val" (value @-> returning (Typ.of_typ ulong))
+    | Ullong -> reader "ctypes_ullong_val" (value @-> returning (Typ.of_typ ullong))
+    | Size_t -> reader "ctypes_size_t_val" (value @-> returning (Typ.of_typ size_t))
+    | Int8_t -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Int16_t -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Int32_t -> reader "Int32_val" (value @-> returning (Typ.of_typ int32_t))
+    | Int64_t -> reader "Int64_val" (value @-> returning (Typ.of_typ int64_t))
+    | Uint8_t -> reader "Uint8_val" (value @-> returning (Typ.of_typ uint8_t))
+    | Uint16_t -> reader "Uint16_val" (value @-> returning (Typ.of_typ uint16_t))
+    | Uint32_t -> reader "Uint32_val" (value @-> returning (Typ.of_typ uint32_t))
+    | Uint64_t -> reader "Uint64_val" (value @-> returning (Typ.of_typ uint64_t))
+    | Camlint -> reader "Int_val" (value @-> returning (Typ.of_typ int))
+    | Nativeint -> reader "Nativeint_val" (value @-> returning (Typ.of_typ nativeint))
+    | Float -> reader "Double_val" (value @-> returning (Typ.of_typ double))
+    | Double -> reader "Double_val" (value @-> returning (Typ.of_typ double))
+    | Complex32 -> reader "ctypes_float_complex_val" (value @-> returning (Typ.of_typ complex32))
+    | Complex64 -> reader "ctypes_double_complex_val" (value @-> returning (Typ.of_typ complex64))
 
   let prim_inj : type a. a Primitives.prim -> (a -> value, value) cfunction =
+    let ty t = Typ.of_typ t in
     let open Primitives in function
-    | Char -> immediater "Val_int" (char @-> returning value)
-    | Schar -> immediater "Val_int" (int @-> returning value)
-    | Uchar -> conser "ctypes_copy_uint8" (uchar @-> returning value)
-    | Short -> immediater "Val_int" (int @-> returning value)
-    | Int -> immediater "Val_int" (int @-> returning value)
-    | Long -> conser "ctypes_copy_long" (long @-> returning value)
-    | Llong -> conser "ctypes_copy_llong" (llong @-> returning value)
-    | Ushort -> conser "ctypes_copy_ushort" (ushort @-> returning value)
-    | Uint -> conser "ctypes_copy_uint" (uint @-> returning value)
-    | Ulong -> conser "ctypes_copy_ulong" (ulong @-> returning value)
-    | Ullong -> conser "ctypes_copy_ullong" (ullong @-> returning value)
-    | Size_t -> conser "ctypes_copy_size_t" (size_t @-> returning value)
-    | Int8_t -> immediater "Val_int" (int @-> returning value)
-    | Int16_t -> immediater "Val_int" (int @-> returning value)
-    | Int32_t -> conser "caml_copy_int32" (int32_t @-> returning value)
-    | Int64_t -> conser "caml_copy_int64" (int64_t @-> returning value)
-    | Uint8_t -> conser "ctypes_copy_uint8" (uint8_t @-> returning value)
-    | Uint16_t -> conser "ctypes_copy_uint16" (uint16_t @-> returning value)
-    | Uint32_t -> conser "ctypes_copy_uint32" (uint32_t @-> returning value)
-    | Uint64_t -> conser "ctypes_copy_uint64" (uint64_t @-> returning value)
-    | Camlint -> immediater "Val_int" (int @-> returning value)
-    | Nativeint -> conser "caml_copy_nativeint" (nativeint @-> returning value)
-    | Float -> conser "caml_copy_double" (double @-> returning value)
-    | Double -> conser "caml_copy_double" (double @-> returning value)
-    | Complex32 -> conser "ctypes_copy_float_complex" (complex32 @-> returning value)
-    | Complex64 -> conser "ctypes_copy_double_complex" (complex64 @-> returning value)
+    | Char -> immediater "Val_int" (ty char @-> returning value)
+    | Schar -> immediater "Val_int" (ty int @-> returning value)
+    | Uchar -> conser "ctypes_copy_uint8" (ty uchar @-> returning value)
+    | Short -> immediater "Val_int" (ty int @-> returning value)
+    | Int -> immediater "Val_int" (ty int @-> returning value)
+    | Long -> conser "ctypes_copy_long" (ty long @-> returning value)
+    | Llong -> conser "ctypes_copy_llong" (ty llong @-> returning value)
+    | Ushort -> conser "ctypes_copy_ushort" (ty ushort @-> returning value)
+    | Uint -> conser "ctypes_copy_uint" (ty uint @-> returning value)
+    | Ulong -> conser "ctypes_copy_ulong" (ty ulong @-> returning value)
+    | Ullong -> conser "ctypes_copy_ullong" (ty ullong @-> returning value)
+    | Size_t -> conser "ctypes_copy_size_t" (ty size_t @-> returning value)
+    | Int8_t -> immediater "Val_int" (ty int @-> returning value)
+    | Int16_t -> immediater "Val_int" (ty int @-> returning value)
+    | Int32_t -> conser "caml_copy_int32" (ty int32_t @-> returning value)
+    | Int64_t -> conser "caml_copy_int64" (ty int64_t @-> returning value)
+    | Uint8_t -> conser "ctypes_copy_uint8" (ty uint8_t @-> returning value)
+    | Uint16_t -> conser "ctypes_copy_uint16" (ty uint16_t @-> returning value)
+    | Uint32_t -> conser "ctypes_copy_uint32" (ty uint32_t @-> returning value)
+    | Uint64_t -> conser "ctypes_copy_uint64" (ty uint64_t @-> returning value)
+    | Camlint -> immediater "Val_int" (ty int @-> returning value)
+    | Nativeint -> conser "caml_copy_nativeint" (ty nativeint @-> returning value)
+    | Float -> conser "caml_copy_double" (ty double @-> returning value)
+    | Double -> conser "caml_copy_double" (ty double @-> returning value)
+    | Complex32 -> conser "ctypes_copy_float_complex" (ty complex32 @-> returning value)
+    | Complex64 -> conser "ctypes_copy_double_complex" (ty complex64 @-> returning value)
 
   let app1 f x = CApp (f, Args (Arg x, End))
   let app2 f x y = CApp (f, Args (Arg x, Args (Arg y, End)))
@@ -129,39 +130,39 @@ struct
 
   let of_fatptr : type a. a typ -> value cexp -> a ptr ceff =
     fun typ x ->
-    app1 (reader "CTYPES_ADDR_OF_FATPTR" (value @-> returning (ptr typ))) x
+    app1 (reader "CTYPES_ADDR_OF_FATPTR" (value @-> returning (Typ.ptr typ))) x
 
   let string_to_ptr : value cexp -> char ptr ceff =
     fun x ->
-    app1 (reader "CTYPES_PTR_OF_OCAML_STRING" (value @-> returning (ptr char))) x
+    app1 (reader "CTYPES_PTR_OF_OCAML_STRING" (value @-> returning (Typ.ptr (Typ.of_typ char)))) x
 
   let float_array_to_ptr : value cexp -> float ptr ceff =
     fun x -> app1 (reader "CTYPES_PTR_OF_FLOAT_ARRAY"
-                          (value @-> returning (ptr double)))
+                          (value @-> returning (Typ.ptr (Typ.of_typ double))))
                   x
 
   let from_ptr : type a. a typ -> a ptr cexp -> value ceff =
     fun typ x -> app1 (conser "CTYPES_FROM_PTR"
-                              (ptr typ @-> returning value))
+                              (Typ.ptr typ @-> returning value))
                       x
 
   let functions : value ptr ceff = CGlobal
     { name = "functions";
       references_ocaml_heap = true;
-      typ = (ptr value) }
+      typ = Typ.(ptr value) }
 
   let caml_callbackN n : (value -> int -> value carray -> value, value) cfunction =
     { fname = "caml_callbackN";
       allocates = true;
       reads_ocaml_heap = true;
-      fn = (value @-> int @-> array n value @-> returning value) }
+      fn = Typ.(value @-> int @-> array n value @-> returning value) }
 
   let copy_bytes : type a. a typ -> (a ptr -> Unsigned.size_t -> value, value) cfunction =
     fun typ ->
     { fname = "ctypes_copy_bytes";
       allocates = true;
       reads_ocaml_heap = true;
-      fn = (ptr typ @-> size_t @-> returning value) }
+      fn = Typ.(ptr typ @-> size_t @-> returning value) }
 
   let sizeof : type a. a typ -> Unsigned.Size_t.t cexp =
     fun typ -> CConst (CSizeof typ)
@@ -174,29 +175,33 @@ struct
                      | NoPrj : ('a, unit) view -> 'a prj_result
 
   let id_view : type a. a typ -> (a, a) view =
-    fun ty -> let id x = x in
-      { read = id; write = id; ty; format = None; format_typ = None }
+    (* Here *)
+    fun {ty_} -> let id x = x in
+      { Static.read = id; write = id; ty=ty_; format = None; format_typ = None }
   let compose_view : type a b c. (a, b) view -> (b, c) view -> (a, c) view =
     fun v1 v2 ->
     let read x = v1.read (v2.read x) and write x = v2.write (v1.write x) in
-    { read; write; format = None; format_typ = None; ty = v2.ty }
+    { Static.read; write; format = None; format_typ = None; ty = v2.Static.ty }
 
-  let rec prj : type a. a typ -> value cexp -> a prj_result =
-    fun ty x -> match ty with
-    | Void -> NoPrj (id_view void)
+  let prj : type a. a typ -> value cexp -> a prj_result =
+    fun ({format} as ty') ->
+    let rec prj  : type a. a typ -> value cexp -> a prj_result =
+    (* Here *)
+    fun ({ty_} as ty') x -> match ty_ with
+    | Void -> NoPrj (id_view (Typ.of_typ void))
     | Primitive p ->
       let { fn } as prj = prim_prj p in
-      Prj (cast ~into:ty (CEff (app1 prj x)))
-    | Pointer t -> Prj (CEff (of_fatptr t x))
+      Prj (cast ~into:ty' (CEff (app1 prj x)))
+    | Pointer t -> Prj (CEff (of_fatptr (Typ.of_typ t) x))
     | Struct s ->
-      Prj (CEff (of_fatptr ty x) >>= fun y -> CEff (CDeref y))
+      Prj (CEff (of_fatptr ty' x) >>= fun y -> CEff (CDeref y))
     | Union u -> 
-      Prj (CEff (of_fatptr ty x) >>= fun y -> CEff (CDeref y))
+      Prj (CEff (of_fatptr ty' x) >>= fun y -> CEff (CDeref y))
     | Abstract _ -> report_unpassable "values of abstract type"
-    | View ({ ty = ty' } as view) -> 
-       begin match prj ty' x with
+    | View ({ Static.ty = ty'' } as view) -> 
+       begin match prj (Typ.of_typ ty'') x with
        | Prj c -> Prj (c >>= fun y ->
-                       CEff (CExp (CCast (ty, y))))
+                       CEff (CExp (CCast ({ty' with format}, y))))
        | OPrj _ -> assert false (* TODO *)
        | NoPrj v -> NoPrj (compose_view view v)
        end
@@ -205,16 +210,18 @@ struct
     | OCaml String -> OPrj (OString, CEff (string_to_ptr x))
     | OCaml Bytes -> OPrj (OBytes, CEff (string_to_ptr x))
     | OCaml FloatArray -> OPrj (OFloatArray, CEff (float_array_to_ptr x))
+    in prj ty'
 
   let rec inj : type a. a typ -> a cexp -> value ceff =
-    fun ty x -> match ty with
+    (* Here *)
+    fun ({ty_} as ty') x -> match ty_ with
     | Void -> val_unit
-    | Primitive p -> app1 (prim_inj p) (CCast (Primitive p, x))
-    | Pointer ty -> from_ptr ty x
-    | Struct s -> app2 (copy_bytes ty) (CAddr x) (sizeof ty)
-    | Union u -> app2 (copy_bytes ty) (CAddr x) (sizeof ty)
+    | Primitive p -> app1 (prim_inj p) (CCast (ty', x))
+    | Pointer ty -> from_ptr (Typ.of_typ ty) x
+    | Struct _ -> app2 (copy_bytes ty') (CAddr x) (sizeof ty')
+    | Union _ -> app2 (copy_bytes ty') (CAddr x) (sizeof ty')
     | Abstract _ -> report_unpassable "values of abstract type"
-    | View {ty = ty'} -> inj ty' (CCast (ty', x))
+    | View {Static.ty = ty'} -> inj (Typ.of_typ ty') (CCast (Typ.of_typ ty', x))
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCaml _ -> report_unpassable "ocaml references as return values"
@@ -286,8 +293,8 @@ struct
                      (v, value) fn -> (_, v) value_conversion ->
                      (value ptr -> int -> value) cfundef =
     fun ~bytename ~stubname:fname fn vconv ->
-    let argv = local "argv" (ptr value) in
-    let argc = local "argc" int in
+    let argv = local "argv" (Typ.ptr value) in
+    let argc = local "argc" (Typ.of_typ int) in
     let f = { fname; allocates = true; reads_ocaml_heap = true; fn } in
     let rec body : type a v. (v, value) fn -> (a, v) value_conversion -> int -> 
                         (v args -> value ccomp) -> value ccomp =
@@ -295,7 +302,7 @@ struct
      | Returns_ _, Value_returning ->
         k End
      | Function_ (_, fn'), Value_arg vconv' ->
-        CEff (CPIndex (CExp (CLocal argv), CConst (CInt i))) >>= fun x ->
+        CEff (CPIndex (CExp (CLocal argv), CConst (CInt i))) >>= fun (x : value cexp) ->
         let k' args = k (Args (Arg x, args)) in
         body fn' vconv' (i+1) k'
      | _ -> assert false
@@ -306,11 +313,11 @@ struct
   let inverse_fn : type a r. stub_name:string -> (a, r) wrapper_function ->
                              r typ -> a cfundef =
     fun ~stub_name (Wrapper (fn, vconv, vfn)) rtyp ->
-    let idx = CLocal (local (Printf.sprintf "fn_%s" stub_name) int) in
+    let idx = CLocal (local (Printf.sprintf "fn_%s" stub_name) (Typ.of_typ int)) in
     let params = params fn in
     let nparams = params_length params in
-    let nargs = local "nargs" int in
-    let locals = local "locals" (array nparams value) in
+    let nargs = local "nargs" (Typ.of_typ int) in
+    let locals = local "locals" (Typ.array nparams value) in
     let rec body : type a. a params -> int -> r ccomp =
      fun params i -> match params with
       | NoParams ->
@@ -330,7 +337,7 @@ struct
          end
       | Param (var, params') ->
          (* locals[i] = Val_Ti(xi); *)
-         CEff (CAssign (CPIndex_ (CVar (`Local (local "locals" (ptr value))),
+         CEff (CAssign (CPIndex_ (CVar (`Local (local "locals" (Typ.ptr value))),
                                   CConst (CInt i)), inj var.typ (CLocal var))) >>
          body params' (i + 1)
     in


### PR DESCRIPTION
Annotate the internal C representation with types, so that the OCaml type checker ensures that C code is constructed in a meaningful way.  This is an internal-only change which leaves the interface unchanged and should have no effects on generated code.

The following regression needs to be fixed before this can be merged:
- bindings involving view types (e.g. `funptr`) should use the associated custom type printer rather than the printer for the underlying type.
