### PR TITLE
Alternative (and simpler) workflow for binding constants

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,8 @@ src/configure/gen_libffi_abi.cm*
 generated_stubs.c
 generated_bindings.ml
 generated_struct_bindings.ml
+generated_simple_struct_bindings.ml
+generated_simple_struct_stubs.c
 ncurses_generated.ml
 ncurses_stubs.c
 date_generated.ml

--- a/Makefile.tests
+++ b/Makefile.tests
@@ -238,6 +238,8 @@ test-enums-structs-generated: \
 test-enums-generated: \
   tests/test-enums/generated_bindings.ml \
   tests/test-enums/generated_stubs.c \
+  tests/test-enums/generated_simple_struct_bindings.ml \
+  tests/test-enums/generated_simple_struct_stubs.c \
 
 tests/test-enums/generated_stubs.c: $(BUILDDIR)/test-enums-stub-generator.native
 	$< --c-file $@
@@ -249,6 +251,10 @@ $(BUILDDIR)/test-enums-ml-struct-stub-generator.native: $(BUILDDIR)/tests/test-e
 	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
 $(BUILDDIR)/tests/test-enums/generated_struct_stubs.c: $(BUILDDIR)/test-enums-struct-stub-generator.native
 	$< --c-struct-file $@
+tests/test-enums/generated_simple_struct_bindings.ml: $(BUILDDIR)/test-enums-stub-generator.native
+	$< --ml-simple-struct-file $@
+tests/test-enums/generated_simple_struct_stubs.c: $(BUILDDIR)/test-enums-stub-generator.native
+	$< --c-simple-struct-file $@
 
 test-structs-stubs.dir  = tests/test-structs/stubs
 test-structs-stubs.threads = yes
@@ -277,6 +283,8 @@ test-structs: $$(NATIVE_TARGET)
 test-structs-generated: \
   tests/test-structs/generated_bindings.ml \
   tests/test-structs/generated_stubs.c \
+  tests/test-structs/generated_simple_struct_bindings.ml \
+  tests/test-structs/generated_simple_struct_stubs.c \
   tests/test-structs/generated_struct_bindings.ml \
   $(BUILDDIR)/tests/test-structs/generated_struct_stubs.c
 
@@ -290,6 +298,10 @@ $(BUILDDIR)/test-structs-ml-stub-generator.native: $(BUILDDIR)/tests/test-struct
 	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
 $(BUILDDIR)/tests/test-structs/generated_struct_stubs.c: $(BUILDDIR)/test-structs-stub-generator.native
 	$< --c-struct-file $@
+tests/test-structs/generated_simple_struct_bindings.ml: $(BUILDDIR)/test-structs-stub-generator.native
+	$< --ml-simple-struct-file $@
+tests/test-structs/generated_simple_struct_stubs.c: $(BUILDDIR)/test-structs-stub-generator.native
+	$< --c-simple-struct-file $@
 
 test-constants-stubs.dir  = tests/test-constants/stubs
 test-constants-stubs.threads = yes
@@ -318,6 +330,8 @@ test-constants: $$(NATIVE_TARGET)
 test-constants-generated: \
   tests/test-constants/generated_bindings.ml \
   tests/test-constants/generated_stubs.c \
+  tests/test-constants/generated_simple_struct_bindings.ml \
+  tests/test-constants/generated_simple_struct_stubs.c \
   tests/test-constants/generated_struct_bindings.ml \
   $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c
 
@@ -331,6 +345,10 @@ $(BUILDDIR)/test-constants-ml-stub-generator.native: $(BUILDDIR)/tests/test-cons
 	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
 $(BUILDDIR)/tests/test-constants/generated_struct_stubs.c: $(BUILDDIR)/test-constants-stub-generator.native
 	$< --c-struct-file $@
+tests/test-constants/generated_simple_struct_bindings.ml: $(BUILDDIR)/test-constants-stub-generator.native
+	$< --ml-simple-struct-file $@
+tests/test-constants/generated_simple_struct_stubs.c: $(BUILDDIR)/test-constants-stub-generator.native
+	$< --c-simple-struct-file $@
 
 
 test-finalisers.dir = tests/test-finalisers
@@ -440,6 +458,8 @@ test-unions: $$(NATIVE_TARGET)
 test-unions-generated: \
   tests/test-unions/generated_bindings.ml \
   tests/test-unions/generated_stubs.c \
+  tests/test-unions/generated_simple_struct_bindings.ml \
+  tests/test-unions/generated_simple_struct_stubs.c \
   tests/test-unions/generated_struct_bindings.ml \
   $(BUILDDIR)/tests/test-unions/generated_struct_stubs.c
 
@@ -453,6 +473,10 @@ $(BUILDDIR)/test-unions-ml-stub-generator.native: $(BUILDDIR)/tests/test-unions/
 	$(CC) -I `$(OCAMLFIND) ocamlc -where | sed 's|\r$$||'` $(CFLAGS) $(LDFLAGS) $(WINLDFLAGS) -o $@ $^
 $(BUILDDIR)/tests/test-unions/generated_struct_stubs.c: $(BUILDDIR)/test-unions-stub-generator.native
 	$< --c-struct-file $@
+tests/test-unions/generated_simple_struct_bindings.ml: $(BUILDDIR)/test-unions-stub-generator.native
+	$< --ml-simple-struct-file $@
+tests/test-unions/generated_simple_struct_stubs.c: $(BUILDDIR)/test-unions-stub-generator.native
+	$< --c-simple-struct-file $@
 
 test-custom_ops.dir = tests/test-custom_ops
 test-custom_ops.threads = yes

--- a/src/cstubs/cstubs_structs.mli
+++ b/src/cstubs/cstubs_structs.mli
@@ -18,3 +18,9 @@ end
 module type BINDINGS = functor (F : TYPE) -> sig end
 
 val write_c : Format.formatter -> (module BINDINGS) -> unit
+
+module Easy :
+sig
+  val write_c : Format.formatter -> prefix:string -> (module BINDINGS) -> unit
+  val write_ml : Format.formatter -> prefix:string -> (module BINDINGS) -> unit
+end

--- a/tests/test-constants/stubs/types.ml
+++ b/tests/test-constants/stubs/types.ml
@@ -29,11 +29,15 @@ struct
   let _LLONG_MIN = constant "LLONG_MIN" llong
   let _ULLONG_MAX = constant "ULLONG_MAX" ullong
   let _INT8_MIN = constant "INT8_MIN" int8_t
-  let _INT16_MIN = constant "INT16_MIN" int16_t
+  (* TODO: simple struct stubs don't yet support multiple bindings
+     for the same name *)
+  (* let _INT16_MIN = constant "INT16_MIN" int16_t *)
   let _INT32_MIN = constant "INT32_MIN" int32_t
   let _INT64_MIN = constant "INT64_MIN" int64_t
   let _INT8_MAX = constant "INT8_MAX" int8_t
-  let _INT16_MAX = constant "INT16_MAX" int16_t
+  (* TODO: simple struct stubs don't yet support multiple bindings
+     for the same name *)
+  (* let _INT16_MAX = constant "INT16_MAX" int16_t *)
   let _INT32_MAX = constant "INT32_MAX" int32_t
   let _INT64_MAX = constant "INT64_MAX" int64_t
   let _UINT8_MAX = constant "UINT8_MAX" uint8_t

--- a/tests/test-constants/test_constants.ml
+++ b/tests/test-constants/test_constants.ml
@@ -12,80 +12,90 @@ open Ctypes
 let testlib = Dl.(dlopen ~filename:"clib/libtest_functions.so" ~flags:[RTLD_NOW])
 
 
-module Constants = Types.Struct_stubs(Generated_struct_bindings)
+module Tests(T: Cstubs.Types.TYPE with type 'a const = 'a) =
+struct
+  module Constants = Types.Struct_stubs(T)
 
+  let constant name typ =
+    Foreign.foreign ~from:testlib ("retrieve_"^ name) (void @-> returning typ) ()
 
-let constant name typ =
-  Foreign.foreign ~from:testlib ("retrieve_"^ name) (void @-> returning typ) ()
+  let test_retrieve_constants _ =
+    begin
+      assert_equal Constants._LONG_MIN (constant "LONG_MIN" long);
+      assert_equal Constants._SCHAR_MIN (constant "SCHAR_MIN" Ctypes.schar);
+      assert_equal Constants._SCHAR_MAX (constant "SCHAR_MAX" Ctypes.schar);
+      assert_equal Constants._UCHAR_MAX (constant "UCHAR_MAX" Ctypes.uchar);
+      assert_equal Constants._CHAR_MIN (constant "CHAR_MIN" Ctypes.char);
+      assert_equal Constants._CHAR_MAX (constant "CHAR_MAX" Ctypes.char);
+      assert_equal Constants._SHRT_MIN (constant "SHRT_MIN" Ctypes.short);
+      assert_equal Constants._SHRT_MAX (constant "SHRT_MAX" Ctypes.short);
+      assert_equal Constants._USHRT_MAX (constant "USHRT_MAX" Ctypes.ushort);
+      assert_equal Constants._UINT_MAX (constant "UINT_MAX" Ctypes.uint);
+      assert_equal Constants._LONG_MAX (constant "LONG_MAX" Ctypes.long);
+      assert_equal Constants._LONG_MIN (constant "LONG_MIN" Ctypes.long);
+      assert_equal Constants._ULONG_MAX (constant "ULONG_MAX" Ctypes.ulong);
+      assert_equal Constants._LLONG_MAX (constant "LLONG_MAX" Ctypes.llong);
+      assert_equal Constants._LLONG_MIN (constant "LLONG_MIN" Ctypes.llong);
+      assert_equal Constants._ULLONG_MAX (constant "ULLONG_MAX" Ctypes.ullong);
+      assert_equal Constants._INT8_MIN (constant "INT8_MIN" Ctypes.int8_t);
+      (* assert_equal Constants._INT16_MIN (constant "INT16_MIN" Ctypes.int16_t); *)
+      assert_equal Constants._INT32_MIN (constant "INT32_MIN" Ctypes.int32_t);
+      assert_equal Constants._INT64_MIN (constant "INT64_MIN" Ctypes.int64_t);
+      assert_equal Constants._INT8_MAX (constant "INT8_MAX" Ctypes.int8_t);
+      (* assert_equal Constants._INT16_MAX (constant "INT16_MAX" Ctypes.int16_t); *)
+      assert_equal Constants._INT32_MAX (constant "INT32_MAX" Ctypes.int32_t);
+      assert_equal Constants._INT64_MAX (constant "INT64_MAX" Ctypes.int64_t);
+      assert_equal Constants._UINT8_MAX (constant "UINT8_MAX" Ctypes.uint8_t);
+      assert_equal Constants._UINT16_MAX (constant "UINT16_MAX" Ctypes.uint16_t);
+      assert_equal Constants._UINT32_MAX (constant "UINT32_MAX" Ctypes.uint32_t);
+      assert_equal Constants._UINT64_MAX (constant "UINT64_MAX" Ctypes.uint64_t);
+      assert_equal Constants._SIZE_MAX (constant "SIZE_MAX" Ctypes.size_t);
+      assert_equal Constants._true true;
+      assert_equal Constants._false false;
+    end
 
+  let test_retrieve_views _ =
+    begin
+      assert_equal
+        Constants.neg_INT16_MAX
+        (Int32.(neg (of_int (constant "INT16_MAX" Ctypes.int16_t))))
+      ;
 
-let test_retrieve_constants _ =
-  begin
-    assert_equal Constants._LONG_MIN (constant "LONG_MIN" long);
-    assert_equal Constants._SCHAR_MIN (constant "SCHAR_MIN" Ctypes.schar);
-    assert_equal Constants._SCHAR_MAX (constant "SCHAR_MAX" Ctypes.schar);
-    assert_equal Constants._UCHAR_MAX (constant "UCHAR_MAX" Ctypes.uchar);
-    assert_equal Constants._CHAR_MIN (constant "CHAR_MIN" Ctypes.char);
-    assert_equal Constants._CHAR_MAX (constant "CHAR_MAX" Ctypes.char);
-    assert_equal Constants._SHRT_MIN (constant "SHRT_MIN" Ctypes.short);
-    assert_equal Constants._SHRT_MAX (constant "SHRT_MAX" Ctypes.short);
-    assert_equal Constants._USHRT_MAX (constant "USHRT_MAX" Ctypes.ushort);
-    assert_equal Constants._UINT_MAX (constant "UINT_MAX" Ctypes.uint);
-    assert_equal Constants._LONG_MAX (constant "LONG_MAX" Ctypes.long);
-    assert_equal Constants._LONG_MIN (constant "LONG_MIN" Ctypes.long);
-    assert_equal Constants._ULONG_MAX (constant "ULONG_MAX" Ctypes.ulong);
-    assert_equal Constants._LLONG_MAX (constant "LLONG_MAX" Ctypes.llong);
-    assert_equal Constants._LLONG_MIN (constant "LLONG_MIN" Ctypes.llong);
-    assert_equal Constants._ULLONG_MAX (constant "ULLONG_MAX" Ctypes.ullong);
-    assert_equal Constants._INT8_MIN (constant "INT8_MIN" Ctypes.int8_t);
-    assert_equal Constants._INT16_MIN (constant "INT16_MIN" Ctypes.int16_t);
-    assert_equal Constants._INT32_MIN (constant "INT32_MIN" Ctypes.int32_t);
-    assert_equal Constants._INT64_MIN (constant "INT64_MIN" Ctypes.int64_t);
-    assert_equal Constants._INT8_MAX (constant "INT8_MAX" Ctypes.int8_t);
-    assert_equal Constants._INT16_MAX (constant "INT16_MAX" Ctypes.int16_t);
-    assert_equal Constants._INT32_MAX (constant "INT32_MAX" Ctypes.int32_t);
-    assert_equal Constants._INT64_MAX (constant "INT64_MAX" Ctypes.int64_t);
-    assert_equal Constants._UINT8_MAX (constant "UINT8_MAX" Ctypes.uint8_t);
-    assert_equal Constants._UINT16_MAX (constant "UINT16_MAX" Ctypes.uint16_t);
-    assert_equal Constants._UINT32_MAX (constant "UINT32_MAX" Ctypes.uint32_t);
-    assert_equal Constants._UINT64_MAX (constant "UINT64_MAX" Ctypes.uint64_t);
-    assert_equal Constants._SIZE_MAX (constant "SIZE_MAX" Ctypes.size_t);
-    assert_equal Constants._true true;
-    assert_equal Constants._false false;
-  end
+      assert_equal
+        Constants.neg_INT16_MIN
+        (Int32.(neg (of_int (constant "INT16_MIN" Ctypes.int16_t))))
+      ;
+    end
 
+  let test_retrieve_enums _ =
+    begin
+      assert_equal
+        [0; 1; 10; 11]
+        Constants.([_A; _B; _C; _D])
+    end
+end
 
-let test_retrieve_views _ =
-  begin
-    assert_equal
-      Constants.neg_INT16_MAX
-      (Int32.(neg (of_int (constant "INT16_MAX" Ctypes.int16_t))))
-    ;
-      
-    assert_equal
-      Constants.neg_INT16_MIN
-      (Int32.(neg (of_int (constant "INT16_MIN" Ctypes.int16_t))))
-    ;
-  end
-
-
-let test_retrieve_enums _ =
-  begin
-    assert_equal
-      [0; 1; 10; 11]
-      Constants.([_A; _B; _C; _D])
-  end
-
+module Stubs_tests = Tests(Generated_struct_bindings)
+module Simple_stubs_tests = Tests(Generated_simple_struct_bindings)
 
 let suite = "Constant tests" >:::
   ["retrieving values of various integer types"
-   >:: test_retrieve_constants;
+   >:: Stubs_tests.test_retrieve_constants;
 
    "retrieving values of view type"
-   >:: test_retrieve_views;
+   >:: Stubs_tests.test_retrieve_views;
 
    "retrieving enumeration constants"
-   >:: test_retrieve_enums;
+   >:: Stubs_tests.test_retrieve_enums;
+
+   "retrieving values of various integer types (simple stubs)"
+   >:: Simple_stubs_tests.test_retrieve_constants;
+
+   "retrieving values of view type (simple stubs)"
+   >:: Simple_stubs_tests.test_retrieve_views;
+
+   "retrieving enumeration constants (simple stubs)"
+   >:: Simple_stubs_tests.test_retrieve_enums;
   ]
 
 

--- a/tests/test-enums/stub-generator/driver.ml
+++ b/tests/test-enums/stub-generator/driver.ml
@@ -7,4 +7,6 @@
 
 (* Stub generation driver for the enum tests. *)
 
-let () = Tests_common.run Sys.argv (module Functions.Stubs)
+let () = Tests_common.run Sys.argv
+    ~structs:(module Types.Struct_stubs)
+    (module Functions.Stubs)

--- a/tests/test-enums/test_enums.ml
+++ b/tests/test-enums/test_enums.ml
@@ -98,6 +98,7 @@ struct
 end
 
 module Enum_stubs_tests = Build_enum_stub_tests(Generated_struct_bindings)
+module Enum_simple_stubs_tests = Build_enum_stub_tests(Generated_simple_struct_bindings)
 module Combined_stub_tests = Enum_stubs_tests.Build_call_tests(Generated_bindings)
 
 
@@ -117,6 +118,12 @@ let suite = "Enum tests" >:::
 
     "arrays of enums"
     >:: Enum_stubs_tests.test_enum_arrays;
+
+    "enums as struct members (simple stubs)"
+    >:: Enum_simple_stubs_tests.test_enum_struct_members;
+
+    "arrays of enums (simple stubs)"
+    >:: Enum_simple_stubs_tests.test_enum_arrays;
   ]
 
 

--- a/tests/test-structs/test_structs.ml
+++ b/tests/test-structs/test_structs.ml
@@ -595,6 +595,12 @@ module Combined_foreign_tests =
 module Combined_stub_tests =
   Struct_stubs_tests.Build_call_tests(Generated_bindings)
 
+module Simple_struct_stubs_tests = Build_struct_stub_tests(Generated_simple_struct_bindings)
+module Combined_foreign_tests' =
+  Simple_struct_stubs_tests.Build_call_tests(Tests_common.Foreign_binder)
+module Combined_stub_tests' =
+  Simple_struct_stubs_tests.Build_call_tests(Generated_bindings)
+
 
 let suite = "Struct tests" >:::
   ["passing struct (foreign)"
@@ -614,6 +620,12 @@ let suite = "Struct tests" >:::
 
    "struct dependencies (stubs)"
    >:: Combined_stub_tests.test_struct_dependencies;
+
+   "struct dependencies (foreign, simple struct stubs)"
+   >:: Combined_foreign_tests'.test_struct_dependencies;
+
+   "struct dependencies (stubs, simple struct stubs)"
+   >:: Combined_stub_tests'.test_struct_dependencies;
 
    "incomplete struct members rejected"
    >:: test_incomplete_struct_members;
@@ -662,6 +674,15 @@ let suite = "Struct tests" >:::
 
    "test adding fields to tagless structs"
    >:: Struct_stubs_tests.test_tagless_structs;
+
+   "test layout of structs with missing fields (simple struct stubs)"
+   >:: Simple_struct_stubs_tests.test_missing_fields;
+
+   "test layout of structs with reordered fields (simple struct stubs)"
+   >:: Simple_struct_stubs_tests.test_reordered_fields;
+
+   "test retrieving information about structs with dependencies (simple struct stubs)"
+   >:: Simple_struct_stubs_tests.test_struct_dependencies;
   ]
 
 

--- a/tests/test-unions/test_unions.ml
+++ b/tests/test-unions/test_unions.ml
@@ -197,6 +197,7 @@ end
 
 
 module Struct_stubs_tests = Build_struct_stub_tests(Generated_struct_bindings)
+module Simple_struct_stubs_tests = Build_struct_stub_tests(Generated_simple_struct_bindings)
 
 (* Check that the address of a union is equal to the addresses of each
    of its members.
@@ -300,8 +301,11 @@ let suite = "Union tests" >:::
    "test adding fields to tagless unions"
    >:: Struct_stubs_tests.test_tagless_unions;
 
-   (* "test layout of unions with missing fields" *)
-   (* >:: Struct_stubs_tests.test_missing_fields; *)
+   "test layout of unions with missing fields"
+   >:: Struct_stubs_tests.test_missing_fields;
+
+   "test layout of unions with missing fields (simple stubs)"
+   >:: Simple_struct_stubs_tests.test_missing_fields;
   ]
 
 


### PR DESCRIPTION
This pull request adds a second way of binding compile-time constants such as enumeration constants, macro values, struct offsets, union sizes, etc..

Bindings written using the old interface can be reused without change.  For example, to create a type corresponding to the following C enum declaration

``` C
enum color {
  red,
  blue,
  green
};
```

you might write:

``` ocaml
module Types(T: Cstubs.TYPES) =
struct

  let colors_t = enum "color"
    [`Red, constant "red" int64;
     `Blue, constant "blue" int64;
     `Green, constant "green" int64]
end
```

Here's how to use the `Types` functor with the existing existing interface (see also #62):
- Pass the `Types` functor to
  [Cstubs.Types.write_c](https://github.com/ocamllabs/ocaml-ctypes/blob/f7d8f63ddc6b23efad4de2f27fafb4edb946680f/src/cstubs/cstubs.mli#L68)
  to generate a C program
- Run the C program to generate an ML module of type `Cstubs.TYPES`.
- Apply `Types` to the generated module to make the compile-time constants available to your program.

Here's how to use the `Types` functor with the new interface in this pull request:
- Pass the `Types` functor to
  [Cstubs_structs.Easy.write_c](https://github.com/yallop/ocaml-ctypes/blob/a34c7fce970faa68c214e7e7e6b3cc6908436145/src/cstubs/cstubs_structs.mli#L24)
  and
  [Cstubs_structs.Easy.write_ml](https://github.com/yallop/ocaml-ctypes/blob/a34c7fce970faa68c214e7e7e6b3cc6908436145/src/cstubs/cstubs_structs.mli#L25)
  to generate C stubs and an ML module of type `Cstubs.TYPES`.
- Apply `Types` to the generated module to make the compile-time constants available to your program.

There's a tradeoff: the new interface is easier to integrate into a build, since the dependencies are less linear.  The existing interface generates slightly faster code, since it inlines the values of the C constants into the ML program.

(This isn't quite ready for merge: it doesn't yet support binding the same constant multiple times under different types.)

Closes #266. 
