### PR TITLE
We don't want coverage on normal build

### DIFF
--- a/ctypes.opam
+++ b/ctypes.opam
@@ -10,7 +10,6 @@ license: "MIT"
 build: [
   [make
     "XEN=%{mirage-xen:enable}%"
-    "COVERAGE=true" {bisect_ppx:installed}
     "libffi.config"
     "ctypes-base"
     "ctypes-stubs"]


### PR DESCRIPTION
Since we already have coverage in the `build-test` we don't need it in the `build` as well.
If you had another solution in mind I can look into that, just let me know.

Resolves #669. 