### PR TITLE
Fix -Wunused-argument for generated C stubs for bytecode

### DIFF
--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -483,7 +483,7 @@ struct
   let byte_stub ~errno ~stub_name fmt fn args =
     begin
       let nargs = List.length args in
-      fprintf fmt "@[value@ %s_byte%d@;@[(value *argv, int argc)@]@]@;@[<2>{@\n"
+      fprintf fmt "@[value@ %s_byte%d@;@[(value *argv, int argc)@]@]@;@[<2>{@\n(void)(argc);\n"
         stub_name nargs;
       fprintf fmt "@[<2>return@ @[%s(@[" stub_name;
       ListLabels.iteri args

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -483,7 +483,7 @@ struct
   let byte_stub ~errno ~stub_name fmt fn args =
     begin
       let nargs = List.length args in
-      fprintf fmt "@[value@ %s_byte%d@;@[(value *argv, int argc)@]@]@;@[<2>{@\n(void)(argc);\n"
+      fprintf fmt "@[value@ %s_byte%d@;@[(value *argv, int argc)@]@]@;@[<2>{@\n(void)(argc);@\n"
         stub_name nargs;
       fprintf fmt "@[<2>return@ @[%s(@[" stub_name;
       ListLabels.iteri args


### PR DESCRIPTION
This is a draft, untested. Related to https://github.com/yallop/ocaml-ctypes/issues/248#issuecomment-1440045648