### PR TITLE
Attach test_funptrs to ctypes-foreign

### DIFF
--- a/tests/test-funptrs/dune
+++ b/tests/test-funptrs/dune
@@ -1,5 +1,6 @@
 (test
  (name test_funptrs)
+ (package ctypes-foreign)
  (link_flags
   (:include ../flags/link-flags.sexp))
  (libraries


### PR DESCRIPTION
This ensures that `dune runtest -p ctypes` works.
