### PR TITLE
dune: use build_if instead of workaround

### DIFF
--- a/ctypes-foreign.opam
+++ b/ctypes-foreign.opam
@@ -13,7 +13,7 @@ homepage: "https://github.com/yallop/ocaml-ctypes"
 doc: "https://yallop.github.io/ocaml-ctypes/"
 bug-reports: "https://github.com/yallop/ocaml-ctypes/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "4.03.0"}
   "integers" {with-test & >= "0.2.2"}
   "ctypes" {= version}
@@ -36,11 +36,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"

--- a/ctypes.opam
+++ b/ctypes.opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/yallop/ocaml-ctypes"
 doc: "https://yallop.github.io/ocaml-ctypes/"
 bug-reports: "https://github.com/yallop/ocaml-ctypes/issues"
 depends: [
-  "dune" {>= "2.9"}
+  "dune" {>= "3.9"}
   "ocaml" {>= "4.03.0"}
   "integers"
   "dune-configurator"
@@ -45,11 +45,9 @@ build: [
     name
     "-j"
     jobs
-    "--promote-install-files=false"
     "@install"
     "@runtest" {with-test}
     "@doc" {with-doc}
   ]
-  ["dune" "install" "-p" name "--create-install-files" name]
 ]
 dev-repo: "git+https://github.com/yallop/ocaml-ctypes.git"

--- a/dune
+++ b/dune
@@ -1,7 +1,7 @@
 (env
  (dev
   (flags
-   (:standard -principal))))
+   (:standard -principal -w -67-69))))
 
 (deprecated_library_name
  (old_public_name "ctypes.foreign")

--- a/dune-project
+++ b/dune-project
@@ -1,4 +1,4 @@
-(lang dune 2.9)
+(lang dune 3.9)
 (name ctypes)
 (version 0.22.0)
 (formatting (enabled_for dune))

--- a/examples/fts/stub-generation/dune
+++ b/examples/fts/stub-generation/dune
@@ -1,13 +1,6 @@
-(* -*- tuareg -*- *)
-
-(* This can be ported to build_if once available, ocaml/dune#7899 *)
-
-let unix = List.mem ("os_type", "Unix") Jbuild_plugin.V1.ocamlc_config
-
-let () = Jbuild_plugin.V1.send @@ if not unix then "" else {|
 (test
  (name fts_cmd)
- (enabled_if
+ (build_if
   (= %{os_type} Unix))
  (libraries fts_stubs fts_generated)
  (package ctypes)
@@ -15,4 +8,3 @@ let () = Jbuild_plugin.V1.send @@ if not unix then "" else {|
  (link_flags
   :standard
   (:include config/c_library_flags.sexp)))
-|}

--- a/tests/test-bigarrays/test_bigarrays.ml
+++ b/tests/test-bigarrays/test_bigarrays.ml
@@ -6,7 +6,6 @@
  *)
 
 module Std_array = Array
-type 'a std_array = 'a array
 
 let _ = Dl.(dlopen ~filename:"../clib/clib.so" ~flags:[RTLD_NOW])
 


### PR DESCRIPTION
As discussed in #588, this uses the proper dune feature instead of OCaml
syntax. It can be merged once requiring dune >= 3.9.0 is acceptable.
