### PR TITLE
Size and align of `size_t` and pointer based on `Sys.word_size`

### DIFF
--- a/src/configure/gen_c_primitives.ml
+++ b/src/configure/gen_c_primitives.ml
@@ -115,10 +115,12 @@ let () =
       |[_,C.C_define.Value.String s] -> s
       |_ -> failwith ("unable to find string definition for " ^ l) in
     print_string header;
-    generate "sizeof" "int" (fun { size } ->
-      printf "%d" (import_int size));
-    generate "alignment" "int" (fun { alignment } ->
-      printf "%d" (import_int alignment));
+    generate "sizeof" "int" (function
+      | { constructor = "Size_t" } -> printf "Sys.word_size / 8"
+      | { size } -> printf "%i" (import_int size));
+    generate "alignment" "int" (function
+      | { constructor = "Size_t" } -> printf "Sys.word_size / 8"
+      | { alignment } -> printf "%i" (import_int alignment));
     generate "name" "string" (fun { typ } ->
       printf "%S" (import_string ("STRINGIFY("^typ^")")));
     generate "format_string" "string option" (fun { format } ->
@@ -129,6 +131,6 @@ let () =
         printf "Some %S" ("%"^(import_string str))
       | No_format ->
         printf "None");
-    printf "let pointer_size = %d\n" (import_int "sizeof(void*)");
-    printf "let pointer_alignment = %d\n" (import_int "alignof(void*)");
+    printf "let pointer_size = Sys.word_size / 8\n";
+    printf "let pointer_alignment = Sys.word_size / 8\n"
   )


### PR DESCRIPTION
Executing a program that uses `ocaml-ctypes` on a platform where the word size differs from the word size of the platform where the program was originally compiled results in memory errors due to the wrong pointer arithmetic. We ran into this issue after first compiling an OCaml program on a 64-bit platform to OCaml bytecode and then compiling the OCaml bytecode to 32-bit WebAssembly (in our case using [wasicaml](https://github.com/remixlabs/wasicaml/) but the same issue is expected using [wasm_of_ocaml](https://github.com/ocaml-wasm/wasm_of_ocaml)).

This PR uses `Sys.word_size / 8` for the size and align of `size_t` and pointers, which resolves the issue (the program runs as bytecode and as Wasm).

My questions are 1) if this is valid for all supported platforms and 2) if `ctypes_primitives.h` requires corresponding modifications.