### PR TITLE
Better syntactic arity for fat pointer writes

### DIFF
--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -120,8 +120,7 @@ let (+@) : type a b. (a, b) pointer -> int -> (a, b) pointer
 let (-@) p x = p +@ (-x)
 
 let (<-@) : type a. a ptr -> a -> unit
-  = fun (CPointer p) ->
-    fun v -> write (Fat.reftype p) v p
+  = fun (CPointer p) v -> write (Fat.reftype p) v p
 
 let from_voidp = castp
 let to_voidp p = castp Void p


### PR DESCRIPTION
Change `<-@` to have syntactic arity 2, not 1.

`<-@` used to have syntactic arity 1, given that it is written as nested `fun`s rather than a single `fun` with multiple parameters. In an upcoming version of OCaml 5, this difference will matter a little for performance, as the syntactic arity will start being used as the runtime arity. `<-@` is usually applied to 2 arguments (I claim), so it's a little better for performance for it to have runtime arity 2 and therefore for those applications to be full applications.

This PR is a no-op for OCaml 5.1.1 and earlier.