### PR TITLE
Add catch-all bigarray kind case to avoid OCaml 5.2.0 compilation error

### DIFF
--- a/src/ctypes/ctypes_bigarray_stubs.ml
+++ b/src/ctypes/ctypes_bigarray_stubs.ml
@@ -34,6 +34,7 @@ let kind : type a b. (a, b) Bigarray_compat.kind -> a kind = function
   | Bigarray_compat.Complex32 -> Kind_complex32
   | Bigarray_compat.Complex64 -> Kind_complex64
   | Bigarray_compat.Char -> Kind_char
+  | _ -> failwith "Unsupported bigarray kind" [@@ocaml.warning "-11"]
 
 external address : 'b -> Ctypes_ptr.voidp
   = "ctypes_bigarray_address"


### PR DESCRIPTION
Closes #762 by turning the compilation error for the new `Float16` bigarray kind into a run time exception.  We should eventually add proper support for `Float16`: see #763.