### PR TITLE
Update CI configuration

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Use OCaml ${{ matrix.ocaml-compiler }}
         uses: ocaml/setup-ocaml@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,9 +1,11 @@
 name: Ctypes
 
 on:
-  - pull_request
-  - push
-  - workflow_dispatch
+  push:
+    branches:
+      - master
+  pull_request:
+  workflow_dispatch:
 
 jobs:
   tests:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -43,6 +43,8 @@ jobs:
             ocaml-compiler: 5.0.0
           - os: ubuntu-latest
             ocaml-compiler: 5.1.0
+          - os: ubuntu-latest
+            ocaml-compiler: 5.2.0
           - os: windows-latest
             ocaml-compiler: 4.13.1
           - os: macos-latest


### PR DESCRIPTION
- avoid duplicate CI runs by restricting push triggering to the master branch
- add configuration for OCaml 5.2
- update the `actions/checkout` action to version 4