### PR TITLE
Add CArray.iteri

### DIFF
--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -293,6 +293,11 @@ sig
   (** [iter f a] is analogous to [Array.iter f a]: it applies [f] in turn to
       all the elements of [a]. *)
 
+  val iteri : (int -> 'a -> unit) -> 'a t -> unit
+  (** [iter f a] is analogous to [Array.iteri f a]: it applies [f] in turn to
+      all the elements of [a] but the function is applied to the index of the 
+      element as first argument, and the element itself as second argument *)
+
   val map : 'b typ -> ('a -> 'b) -> 'a t -> 'b t
   (** [map t f a] is analogous to [Array.map f a]: it creates a new array with
       element type [t] whose elements are obtained by applying [f] to the

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -245,6 +245,11 @@ struct
       f (unsafe_get a i)
     done
 
+  let iteri f a =
+    for i = 0 to length a - 1 do
+      f i (unsafe_get a i)
+    done
+
   let map typ f a =
     let l = length a in
     let r = make typ l in

--- a/tests/test-arrays/test_array.ml
+++ b/tests/test-arrays/test_array.ml
@@ -107,6 +107,21 @@ let test_iter _ =
 
 
 (*
+  Test the CArray.iteri function
+ *)
+ let test_iteri _ =
+  let r = ref 0 in
+  let a = CArray.of_list int [1; 2; 3] in
+  let () = CArray.iteri (fun i v -> r := !r + i + v) a in
+  assert_equal !r 9;
+
+  let r = ref 0 in
+  let a = CArray.of_list int [] in
+  let () = CArray.iteri (fun _ -> assert false) a in
+  assert_equal !r 0
+
+
+(*
   Test the CArray.map function
  *)
 let test_map _ =
@@ -369,6 +384,9 @@ let suite = "Array tests" >:::
 
    "CArray.iter "
     >:: test_iter;
+
+    "CArray.iteri "
+    >:: test_iteri;
 
    "CArray.map "
     >:: test_map;


### PR DESCRIPTION
# Description

Hi !

Working with Ctypes I realized I needed a `CArray.iteri` method in order to iter over a carray passing the index to the argument function. 

As it doesn't exist I felt it was time for me to do my first open source PR :)

## Type of change

`val iteri : (int -> 'a -> unit) -> 'a t -> unit`

This is a new feature, non breaking that just adds a functionality. 

## How Has This Been Tested?

I tried to stick with testing and coding style of the already existing `CArray.iter`function:
 - First test checks that the 3 loops of value + index indeed equals 9 ->  `9 = (0 + 1 ) + (1 + 2 ) + (2 + 3) `
 - Second test checks with an empty list.

## If you believe this change is futile for the code base

No worry, I just wanted to learn how to do an opensource PR.
