### PR TITLE
Add support for 'const' and 'volatile'

### DIFF
--- a/examples/fts/stub-generation/bindings/fts_bindings.ml
+++ b/examples/fts/stub-generation/bindings/fts_bindings.ml
@@ -19,7 +19,7 @@ struct
      int ( *compar)(const FTSENT **, const FTSENT ** ));
   *)
   let _fts_open = foreign "fts_open"
-    (ptr (ptr char) @-> int @-> compar_typ_opt @-> returning (ptr fts))
+    (ptr (const (ptr char)) @-> int @-> compar_typ_opt @-> returning (ptr fts))
 
   (* FTSENT *fts_read(FTS *ftsp); *)
   let _fts_read = foreign "fts_read" (* ~check_errno:true *)

--- a/examples/fts/stub-generation/bindings/fts_types.ml
+++ b/examples/fts/stub-generation/bindings/fts_types.ml
@@ -107,6 +107,7 @@ struct
 
   type t = ftsent structure ptr
   let t = ptr ftsent
+  let const_t = ptr (const ftsent)
 
   let info : t -> fts_info
     = fun t -> fts_info_of_int (UShort.to_int (getf !@t fts_info))
@@ -155,10 +156,12 @@ struct
 
   type compar_typ = t ptr -> t ptr -> int
   let compar_typ : compar_typ typ =
-    Foreign.funptr (ptr FTSENT.t @-> ptr FTSENT.t @-> returning int)
+    Foreign.funptr
+      (ptr FTSENT.const_t @-> ptr FTSENT.const_t @-> returning int)
   type compar_typ_opt = compar_typ option
   let compar_typ_opt : compar_typ_opt typ =
-    Foreign.funptr_opt (ptr FTSENT.t @-> ptr FTSENT.t @-> returning int)
+    Foreign.funptr_opt
+      (ptr FTSENT.const_t @-> ptr FTSENT.const_t @-> returning int)
 
   type fts
   let struct_fts : fts structure typ = structure "FTS"

--- a/src/cstubs/cstubs_analysis.ml
+++ b/src/cstubs/cstubs_analysis.ml
@@ -106,6 +106,7 @@ let rec allocation : type a. a typ -> a allocation = function
    | `Alloc a -> `Alloc (Alloc_view (v, a))
    | `Noalloc na -> `Noalloc (Noalloc_view (v, na))
    end
+ | Qualified (_, ty) -> allocation ty
  | Array _ -> `Alloc Alloc_array
  | Bigarray ba -> `Alloc (Alloc_bigarray ba)
  | OCaml _ -> `Alloc Alloc_pointer

--- a/src/cstubs/cstubs_generate_c.ml
+++ b/src/cstubs/cstubs_generate_c.ml
@@ -147,6 +147,7 @@ struct
             `Deref (`Cast (Ty (ptr orig), y)))
     | Abstract _ -> report_unpassable "values of abstract type"
     | View { ty } -> prj ty ~orig x
+    | Qualified (_, ty) -> prj ty ~orig x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCaml String -> Some (string_to_ptr x)
@@ -165,6 +166,7 @@ struct
     | Union u -> `App (copy_bytes, [`Addr (x :> cvar); `Int (Signed.SInt.of_int (sizeof ty))])
     | Abstract _ -> report_unpassable "values of abstract type"
     | View { ty } -> inj ty x
+    | Qualified (_, ty) -> inj ty x
     | Array _ -> report_unpassable "arrays"
     | Bigarray _ -> report_unpassable "bigarrays"
     | OCaml _ -> report_unpassable "ocaml references as return values"
@@ -364,6 +366,7 @@ struct
     | Pointer _ -> Generate_C.of_fatptr x
     | Funptr _ -> Generate_C.of_fatptr x
     | View { ty } -> prj ty ~orig x
+    | Qualified (_, ty) -> prj ty ~orig x
     | t -> unsupported t
 
   let prj ty x = prj ty ~orig:ty x

--- a/src/ctypes-foreign/ctypes_ffi.ml
+++ b/src/ctypes-foreign/ctypes_ffi.ml
@@ -69,6 +69,7 @@ struct
     | Union _                             -> report_unpassable "unions"
     | Struct ({ spec = Complete _ } as s) -> struct_arg_type s
     | View { ty }                         -> arg_type ty
+    | Qualified (_, ty)                   -> arg_type ty
     | Array _                             -> report_unpassable "arrays"
     | Bigarray _                          -> report_unpassable "bigarrays"
     | Abstract _                          -> (report_unpassable

--- a/src/ctypes/cstubs_internals.mli
+++ b/src/ctypes/cstubs_internals.mli
@@ -37,6 +37,7 @@ type 'a typ = 'a Ctypes_static.typ =
   | Union           : 'a Ctypes_static.union_type      -> 'a Ctypes_static.union typ
   | Abstract        : Ctypes_static.abstract_type      -> 'a Ctypes_static.abstract typ
   | View            : ('a, 'b) view             -> 'a typ
+  | Qualified       : Ctypes_static.qualifier * 'a typ -> 'a typ
   | Array           : 'a typ * int              -> 'a Ctypes_static.carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t -> 'a typ
   | OCaml           : 'a ocaml_type             -> 'a ocaml typ

--- a/src/ctypes/ctypes.mli
+++ b/src/ctypes/ctypes.mli
@@ -118,6 +118,16 @@ include Ctypes_types.TYPE
  with type 'a typ = 'a Ctypes_static.typ
   and type ('a, 's) field := ('a, 's) field
 
+(** {3 Qualified types} *)
+
+val const : 'a typ -> 'a typ
+(** [const t] const-qualifies the type [t].  At present the only
+    effect is that the type is marked 'const' in generated code. *)
+
+val volatile : 'a typ -> 'a typ
+(** [volatile t] volatile-qualifies the type [t].  At present the only
+    effect is that the type is marked 'volatile' in generated code. *)
+
 (** {3 Operations on types} *)
 
 val sizeof : 'a typ -> int

--- a/src/ctypes/ctypes_memory.ml
+++ b/src/ctypes/ctypes_memory.ml
@@ -38,6 +38,7 @@ let rec build : type a b. a typ -> (_, b typ) Fat.t -> a
     | View { read; ty } ->
       let buildty = build ty in
       (fun buf -> read (buildty buf))
+    | Qualified (_, ty) -> build ty
     | OCaml _ -> (fun buf -> assert false)
     (* The following cases should never happen; non-struct aggregate
        types are excluded during type construction. *)
@@ -76,6 +77,7 @@ let rec write : type a b. a typ -> a -> (_, b) Fat.t -> unit
     | View { write = w; ty } ->
       let writety = write ty in
       (fun v -> writety (w v))
+    | Qualified (_, ty) -> write ty
     | OCaml _ -> raise IncompleteType
 
 let null : unit ptr = CPointer (Fat.make ~managed:None ~reftyp:Void Raw.null)

--- a/src/ctypes/ctypes_static.mli
+++ b/src/ctypes/ctypes_static.mli
@@ -26,6 +26,8 @@ type 'a structspec =
     Incomplete of incomplete_size
   | Complete of structured_spec
 
+type qualifier = Const | Volatile
+
 type _ typ =
     Void            :                       unit typ
   | Primitive       : 'a Ctypes_primitive_types.prim -> 'a typ
@@ -35,6 +37,7 @@ type _ typ =
   | Union           : 'a union_type      -> 'a union typ
   | Abstract        : abstract_type      -> 'a abstract typ
   | View            : ('a, 'b) view      -> 'a typ
+  | Qualified       : qualifier * 'a typ -> 'a typ
   | Array           : 'a typ * int       -> 'a carray typ
   | Bigarray        : (_, 'a, _) Ctypes_bigarray.t
                                          -> 'a typ
@@ -180,6 +183,8 @@ val union : string -> 'a union typ
 val offsetof : ('a, 'b) field -> int
 val field_type : ('a, 'b) field -> 'a typ
 val field_name : ('a, 'b) field -> string
+val const : 'a typ -> 'a typ
+val volatile : 'a typ -> 'a typ
 
 exception IncompleteType
 exception ModifyingSealedType of string

--- a/src/ctypes/ctypes_type_printing.ml
+++ b/src/ctypes/ctypes_type_printing.ml
@@ -9,8 +9,14 @@
 
 open Ctypes_static
 
-(* See type_printing.mli for the documentation of [format context]. *)
+(* See ctypes_type_printing.mli for the documentation of [format_context]. *)
 type format_context = [ `toplevel | `array | `nonarray ]
+
+let format_qualifier : Format.formatter -> qualifier -> unit =
+  fun fmt q ->
+  match q with
+  | Const -> Format.fprintf fmt "const"
+  | Volatile -> Format.fprintf fmt "volatile"
 
 let rec format_typ' : type a. a typ ->
   (format_context -> Format.formatter -> unit) ->
@@ -26,6 +32,10 @@ let rec format_typ' : type a. a typ ->
       format (k `nonarray) fmt
     | View { ty }, context ->
       format_typ' ty k context fmt
+    | Qualified (q, ty), ctxt ->
+       format_typ' ty 
+         (fun context fmt ->
+           fprintf fmt "@ %a%t" format_qualifier q (k context)) ctxt fmt
     | Abstract { aname }, _ ->
       fprintf fmt "%s%t" aname (k `nonarray)
     | Struct { tag = "" ; fields }, _ ->

--- a/src/ctypes/ctypes_types.mli
+++ b/src/ctypes/ctypes_types.mli
@@ -383,4 +383,6 @@ sig
   val static_funptr : 'a fn -> 'a Ctypes_static.static_funptr typ
   (** Construct a function pointer type from an existing function type
       (called the {i reference type}).  *)
+
+  val const : 'a typ -> 'a typ
 end

--- a/src/ctypes/ctypes_value_printing.ml
+++ b/src/ctypes/ctypes_value_printing.ml
@@ -29,6 +29,7 @@ let rec format : type a. a typ -> Format.formatter -> a -> unit
       | None -> format ty fmt (write v)
       | Some f -> f fmt v
     end
+  | Qualified (_, ty) -> format ty fmt v
 and format_structured : type a b. Format.formatter -> (a, b) structured -> unit
   = fun fmt ({structured = CPointer p} as s) ->
     let open Format in

--- a/tests/test-cstdlib/stubs/functions.ml
+++ b/tests/test-cstdlib/stubs/functions.ml
@@ -49,12 +49,12 @@ struct
 
   let qsort = foreign "qsort"
     (ptr void @-> size_t @-> size_t @->
-     funptr Ctypes.(ptr void @-> ptr void @-> returning int) @->
+     funptr Ctypes.(ptr (const void) @-> ptr (const void) @-> returning int) @->
      returning void)
 
   let bsearch = foreign "bsearch"
-    (ptr void @-> ptr void @-> size_t @-> size_t @->
-     funptr Ctypes.(ptr void @-> ptr void @-> returning int) @->
+    (ptr (const void) @-> ptr (const void) @-> size_t @-> size_t @->
+     funptr Ctypes.(ptr (const void) @-> ptr (const void) @-> returning int) @->
      returning (ptr void))
 
   let strlen = foreign "strlen" (ptr char @-> returning size_t)

--- a/tests/test-type_printing/test_type_printing.ml
+++ b/tests/test-type_printing/test_type_printing.ml
@@ -66,11 +66,17 @@ let test_atomic_printing _ =
     assert_typ_printed_as "int32_t"
       int32_t;
 
+    assert_typ_printed_as "int32_t const"
+      (const int32_t);
+
     assert_typ_printed_as ~name:"f" "int64_t f"
       int64_t;
 
     assert_typ_printed_as "unsigned char"
       uchar;
+
+    assert_typ_printed_as "unsigned char volatile"
+      (volatile uchar);
 
     assert_typ_printed_as "_Bool"
       bool;
@@ -126,6 +132,15 @@ let test_pointer_printing _ =
 
     assert_typ_printed_as "unsigned long long **"
       (ptr (ptr ullong));
+
+    assert_typ_printed_as "unsigned long long const **"
+      (ptr (ptr (const ullong)));
+
+    assert_typ_printed_as "unsigned long long * const *"
+      (ptr (const (ptr ullong)));
+
+    assert_typ_printed_as "unsigned long long ** const"
+      (const (ptr (ptr ullong)));
 
     assert_typ_printed_as ~name:"b" "char *****b"
       (ptr (ptr (ptr (ptr (ptr char)))));


### PR DESCRIPTION
Add two new operations on types:

```ocaml
val const : 'a typ -> 'a typ
(** [const t] const-qualifies the type [t].  At present the only
    effect is that the type is marked 'const' in generated code. *)

val volatile : 'a typ -> 'a typ
(** [volatile t] volatile-qualifies the type [t].  At present the only
    effect is that the type is marked 'volatile' in generated code. *)
```